### PR TITLE
Fix: Make blog page footer consistent with other pages

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -107,16 +107,24 @@
             </div>
             <div class="footer-contact">
                 <div class="footer-column">
-                    <h4>Besuchen Sie uns</h4>
-                    <p>Musterstraße 123<br>12345 Berlin<br>Deutschland</p>
+                    <h4>Adresse/adress</h4>
+                    <p>Le Châtelet<br>
+                    Inh. Jörg Jörgsen<br>
+                    Schloßallee 5<br>
+                    20095 Hamburg</p>
                 </div>
                 <div class="footer-column">
-                    <h4>Kontaktieren Sie uns</h4>
-                    <p><a href="mailto:info@le-chatelet.de">info@le-chatelet.de</a></p>Telefon: +49 30 12345678</p>
+                    <h4>Telefon/phone</h4>
+                    <p>+49(0)0000 12 34 567</p>
+                    <p>Bürozeit 9:00-12:00 Uhr</p>
+                    <h4>eMail</h4>
+                    <p><a href="mailto:info@le-chatelet.de">info@le-chatelet.de</a></p>
                 </div>
             </div>
         </div>
-        <a href="#top" class="back-to-top" style="display: none;">&uarr;</a>
+        <a href="#" class="back-to-top" title="Back to Top">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" width="24px" height="24px"><path d="M0 0h24v24H0z" fill="none"/><path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"/></svg>
+        </a>
         <div class="footer-legal">
             <a href="impressum.html">Impressum</a> | <a href="datenschutz.html">Datenschutz</a> | <a href="cookie-richtlinie.html">Cookie-Richtlinie</a>
         </div>


### PR DESCRIPTION
The footer on blog.html contained placeholder content and an outdated 'back-to-top' link. This change replaces the incorrect footer with the standard site footer, ensuring a consistent design and accurate contact information across the website.